### PR TITLE
Fix automation testing

### DIFF
--- a/provisionamento/automation.sh
+++ b/provisionamento/automation.sh
@@ -5,7 +5,7 @@ LOGSTASH_VERSION="7.13.1"
 LOGSTASH_URL="https://artifacts.elastic.co/downloads/logstash/logstash-${LOGSTASH_VERSION}-amd64.deb"
 DEPS_PACKAGES="apt-transport-https ca-certificates curl gnupg-agent software-properties-common python3 python3-pip vim openjdk-11-jre wget tree"
 PACKAGES="docker-ce docker-compose"
-PIP_PACKAGES="ComplexHTTPServer ansible==2.9"
+PIP_PACKAGES="ComplexHTTPServer ansible==4.10"
 
 
 # Registrando dia do Provision

--- a/provisionamento/automation.sh
+++ b/provisionamento/automation.sh
@@ -5,7 +5,8 @@ LOGSTASH_VERSION="7.13.1"
 LOGSTASH_URL="https://artifacts.elastic.co/downloads/logstash/logstash-${LOGSTASH_VERSION}-amd64.deb"
 DEPS_PACKAGES="apt-transport-https ca-certificates curl gnupg-agent software-properties-common python3 python3-pip vim openjdk-11-jre wget tree"
 PACKAGES="docker-ce docker-compose"
-PIP_PACKAGES="ComplexHTTPServer ansible"
+PIP_PACKAGES="ComplexHTTPServer ansible==2.9"
+
 
 # Registrando dia do Provision
 sudo date >> /var/log/vagrant_provision.log
@@ -38,6 +39,12 @@ sudo apt-get --allow-releaseinfo-change update -qq >/dev/null 2>>/var/log/vagran
 	sudo apt-get install -qq -y ${DEPS_PACKAGES} ${PACKAGES} >/dev/null 2>>/var/log/vagrant_provision.log
 
 validateCommand "Instalação de Pacotes"
+
+# automation: [ERROR] Pacotes Python
+# The SSH command responded with a non-zero exit status. Vagrant
+# assumes that this means the command failed. The output for this command
+# should be in the log above. Please read the output to determine what
+# went wrong.
 
 # Instalando Pacotes do Python
 pip3 install -q ${PIP_PACKAGES} >/dev/null 2>>/var/log/vagrant_provision.log && \

--- a/provisionamento/testing.sh
+++ b/provisionamento/testing.sh
@@ -31,12 +31,31 @@ else
   echo "[OK] SSH KEY"
 fi
 
+
+# ----------------------------------
+# /var/log/vagrant_provision.log
+# Correção erro:
+# - Error: GPG check FAILED
+
 # Atualizando RPM
-sudo dnf update rpm -y >/dev/null 2>>/var/log/vagrant_provision.log
+# sudo dnf update rpm -y >/dev/null 2>>/var/log/vagrant_provision.log
 
 # Solução temporaria para EOL Centos 8
-sudo rpm -Uhv --nodeps http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-release-8.5-3.el8.noarch.rpm >/dev/null 2>>/var/log/vagrant_provision.log
+# sudo rpm -Uhv --nodeps https://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-repos-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-gpg-keys-8-3.el8.noarch.rpm http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/Packages/centos-stream-release-8.5-3.el8.noarch.rpm >/dev/null 2>>/var/log/vagrant_provision.log
+# ----------------------------------
 
+# Alterando os repositórios do CentOS 8 para o mirror Vault, pois os mirrors oficiais foram depreciados.
+sudo sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+sudo sed -i 's|^#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+# Ajustando o repositório Epel-8. countme não é mais permitido.
+sudo sed -i 's/^countme=1/#&/' /etc/yum.repos.d/epel*.repo
+
+# Limpando o cache do repositório
+sudo dnf clean all
+
+# Atualizando o RPM
+sudo dnf update rpm -q -y
 
 
 # Instalando Pacotes


### PR DESCRIPTION
# Este PR tem como objetivo corrigir um erro identificado durante o processo de provisionamento do Vagrant. O erro estava relacionado à falha na verificação GPG durante a atualização do RPM da maquina "testing". Para resolver esse problema, foram implementadas as seguintes alterações:

foram realizadas as seguintes alterações adicionais:
# - Alteração dos repositórios do CentOS 8 para o mirror Vault, descomentando a linha de `mirrorlist` e atualizando a URL para `baseurl`.
sudo sed -i 's/^mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
sudo sed -i 's|^#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*

# - Ajuste do repositório Epel-8, desabilitando a contagem de pacotes.
sudo sed -i 's/^countme=1/#&/' /etc/yum.repos.d/epel*.repo

# - Limpeza do cache do repositório.
sudo dnf clean all

# - Atualização do RPM.
sudo dnf update rpm -q -y


# Também foi alterado a versão do módulo do ansible utilizado na maquina "automation";
# - PIP_PACKAGES="ComplexHTTPServer ansible==4.10"
